### PR TITLE
fixes bug with facebook page names with a "."

### DIFF
--- a/src/MediaEmbed/Data/stubs.php
+++ b/src/MediaEmbed/Data/stubs.php
@@ -48,7 +48,7 @@ $stubs = [
 		'name' => 'Facebook',
 		'website' => 'https://www.facebook.com',
 		'url-match' => [
-			'https://www.facebook.com/[0-9a-z-_]+/videos/([0-9]+)/'
+			'https://www.facebook.com/[0-9a-z-_.]+/videos/([0-9]+)/'
 		],
 		'embed-src' => 'https://www.facebook.com/video/embed?video_id=$2',
 		'embed-width' => '480',

--- a/tests/MediaEmbed/MediaEmbedTest.php
+++ b/tests/MediaEmbed/MediaEmbedTest.php
@@ -20,7 +20,7 @@ class MediaEmbedTest extends \PHPUnit_Framework_TestCase {
 		'https://www.youtube.com/embed/yWm4YwqO93I?rel=0' => 'yWm4YwqO93I',
 		'http://youtu.be/MKlq4gQKtU0' => 'MKlq4gQKtU0',
 		'https://www.facebook.com/mega90er/videos/1309058692443747/' => '1309058692443747',
-
+                'https://www.facebook.com/diginights.HN/videos/1231155290281511/' => '1231155290281511',
 		// Not yet possible
 		//'https://www.youtube.com/playlist?list=PLD1FA4687572EDB23' => 'PLD1FA4687572EDB23',
 


### PR DESCRIPTION
Facebook has also page slugs with a dot (e.g. https://www.facebook.com/diginights.HN/videos/1231155290281511/) which will now also be recognized.