### PR TITLE
Update MediaObject.php, call to htmlspecialchars

### DIFF
--- a/src/MediaEmbed/Object/MediaObject.php
+++ b/src/MediaEmbed/Object/MediaObject.php
@@ -621,7 +621,7 @@ class MediaObject implements ObjectInterface {
 	 * @return string
 	 */
 	protected function _esc($text) {
-		return htmlspecialchars($text, ENT_QUOTES, null, false);
+		return htmlspecialchars($text, ENT_QUOTES, '', false);
 	}
 
 }


### PR DESCRIPTION
Updated the htmlspecialchars call, since the third parameter (charset) must be an empty string in order to activate autodetection (from http://php.net/manual/en/function.htmlspecialchars.php).

On PHP version 7.0.23-1~dotdeb+8.1, passing null as third parameter gives an Exception:
> [2018-01-05 08:49:42] production.ERROR: htmlspecialchars(): charset `e_value' not supported, assuming utf-8 at /.../vendor/dereuromark/media-embed/src/MediaEmbed/Object/MediaObject.php:624
  